### PR TITLE
Hashed columns are not show, hashed columns are donated instead of th…

### DIFF
--- a/src/framework/visualisation/react/ui/elements/table.tsx
+++ b/src/framework/visualisation/react/ui/elements/table.tsx
@@ -68,12 +68,18 @@ export const Table = ({ id, head, body, readOnly = false, adjustable, pageSize =
     }
   }
 
+
   const [state, setState] = React.useState<State>(initialState)
 
   const copy = prepareCopy(locale)
 
   function display (element: keyof Visibility): string {
     return visible(element) ? '' : 'hidden'
+  }
+
+  function matchColsThatStartWithHashed (props: Weak<PropsUITableHead>): Array<boolean> {
+    const regex : RegExp = /^Hashed.*/;
+    return props.cells.map((cell) => regex.test(cell.text))
   }
 
   function visible (element: keyof Visibility): boolean {
@@ -128,11 +134,24 @@ export const Table = ({ id, head, body, readOnly = false, adjustable, pageSize =
     return filteredRows.current.slice(offset, offset + pageSize)
   }
 
+
+// ######################################################
   function renderHeadRow (props: Weak<PropsUITableHead>): JSX.Element {
+
+        let cells : JSX.Element[] = []
+        const colsThatStartWithHashed : Array<boolean> = matchColsThatStartWithHashed(head)
+
+        props.cells.forEach((cell, index) => { 
+            if (colsThatStartWithHashed[index] === false) {
+                cells.push(renderHeadCell(cell, index))
+                console.log(index)
+            }
+        })
+
     return (
       <tr>
         {state.edit ? renderHeadCheck() : ''}
-        {props.cells.map((cell, index) => renderHeadCell(cell, index))}
+        {cells}
       </tr>
     )
   }
@@ -158,11 +177,22 @@ export const Table = ({ id, head, body, readOnly = false, adjustable, pageSize =
     return state.rows.map((row, index) => renderRow(row, index))
   }
 
+// ######################################################
   function renderRow (row: PropsUITableRow, rowIndex: number): JSX.Element {
+
+    let cells : JSX.Element[] = []
+    const colsThatStartWithHashed : Array<boolean> = matchColsThatStartWithHashed(head)
+
+    row.cells.forEach((cell, index) => { 
+        if (colsThatStartWithHashed[index] === false) {
+            cells.push(renderRowCell(cell, index))
+        }
+    })
+
     return (
       <tr key={`${rowIndex}`} className='hover:bg-grey6'>
         {state.edit ? renderRowCheck(row.id) : ''}
-        {row.cells.map((cell, cellIndex) => renderRowCell(cell, cellIndex))}
+        {cells}
       </tr>
     )
   }

--- a/src/framework/visualisation/react/ui/prompts/consent_form.tsx
+++ b/src/framework/visualisation/react/ui/prompts/consent_form.tsx
@@ -140,10 +140,39 @@ export const ConsentForm = (props: Props): JSX.Element => {
     return { [id]: data }
   }
 
+  // ################################################################
+  // changes by niek here
+  // this code will exclude all cols before a column that starts with "Hashed" 
+  
+  function matchColsThatStartWithHashed (props: Weak<PropsUITableHead>): Array<boolean> {
+    const regex : RegExp = /^Hashed.*/;
+    return props.cells.map((cell) => regex.test(cell.text))
+  }
+
   function serializeRow (row: PropsUITableRow, head: PropsUITableHead): any {
     assert(row.cells.length === head.cells.length, `Number of cells in row (${row.cells.length}) should be equals to number of cells in head (${head.cells.length})`)
-    const keys = head.cells.map((cell) => cell.text)
-    const values = row.cells.map((cell) => cell.text)
+
+    let colsToDelete : Array<boolean> = matchColsThatStartWithHashed(head)
+    const firstElement = colsToDelete.shift()
+    if (firstElement !== undefined) {
+      colsToDelete.push(firstElement)
+    }
+
+    let keys : Array<string> = []
+    let values : Array<string> = []
+
+    head.cells.forEach((cell, index) => {
+      if (colsToDelete[index] !== true) {
+        keys.push(cell.text)
+      }
+    })
+
+    row.cells.forEach((cell, index) => {
+      if (colsToDelete[index] !== true) {
+        values.push(cell.text)
+      }
+    })
+
     return _.fromPairs(_.zip(keys, values))
   }
 


### PR DESCRIPTION
Very ugly code :) but does the job!

It checks whether the column named starts with "Hashed", in that case the column is not rendered.

At the donate step, the column before a column that starts with "Hashed" is omitted from the donation.